### PR TITLE
Added 'summaryOnly' value to 'RouteRepresentation' enum

### DIFF
--- a/AzureMapsRestToolkit/AzureMapsRestToolkit/Route/RouteRepresentation.cs
+++ b/AzureMapsRestToolkit/AzureMapsRestToolkit/Route/RouteRepresentation.cs
@@ -13,6 +13,11 @@
         /// <summary>
         /// Includes route geometry in the response.
         /// </summary>
-        polyline
+        polyline,
+
+        /// <summary>
+        /// Summary as per polyline but excluding the point geometry elements for the routes in the response.
+        /// </summary>
+        summaryOnly
     }
 }


### PR DESCRIPTION
Added 'summaryOnly' value to 'RouteRepresentation' enum / 'none' value causes Bad Request.