### PR TITLE
Fix typo in repository URL

### DIFF
--- a/AzureMapsRestToolkit/AzureMapsRestToolkit/AzureMapsRestToolkit.csproj
+++ b/AzureMapsRestToolkit/AzureMapsRestToolkit/AzureMapsRestToolkit.csproj
@@ -5,7 +5,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>.Net standard library for Azure Maps Services</Description>
     <PackageProjectUrl>https://github.com/perfahlen/AzureMapsRestServices</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/perfahlen/AzureMapsRestServicet</RepositoryUrl>
+    <RepositoryUrl>https://github.com/perfahlen/AzureMapsRestServices</RepositoryUrl>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>


### PR DESCRIPTION
Current repository URL in csproj has typo, so link in nuget.org gives 404

Fixing to correct link