### PR TITLE
Add EntityType to SearchResult

### DIFF
--- a/AzureMapsRestToolkit/AzureMapsRestToolkit/Search/SearchResult.cs
+++ b/AzureMapsRestToolkit/AzureMapsRestToolkit/Search/SearchResult.cs
@@ -50,6 +50,12 @@ namespace AzureMapsToolkit.Search
         [JsonPropertyName("type")]
         public string Type { get; set; }
 
+        /// <summary>
+        /// Entity type property
+        /// </summary>
+        [JsonPropertyName("entityType")]
+        public string EntityType { get; set; }
+
 
         /// <summary>
         /// The viewport that covers the result represented by the top-left and bottom-right coordinates of the viewport.


### PR DESCRIPTION
In structured or query searches for e.g. "Berlin", there will be multiple results with the type `Geography` where another field `entityType` is present.

This field gives more information about the geography type. See the docs: https://docs.microsoft.com/en-us/javascript/api/azure-maps-rest/atlas.service.models.entitytype?view=azure-maps-typescript-latest